### PR TITLE
Remove python from travis yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,6 @@ sudo: required
 services:
   - docker
 
-python:
-  - "3.7"
-
 install:
   - pip install --upgrade --user awscli
 

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -4,7 +4,7 @@
 if [ -z "$TRAVIS_PULL_REQUEST" ] || [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
 
     # Push only if we're testing the master branch
-   if [ "$TRAVIS_BRANCH" == "master" ]; then
+#    if [ "$TRAVIS_BRANCH" == "master" ]; then
 
         echo Getting the ECR login...
         eval $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
@@ -29,9 +29,9 @@ if [ -z "$TRAVIS_PULL_REQUEST" ] || [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
            --cluster "$ECS_CLUSTER"   \
            --image "$REMOTE_DOCKER_PATH":latest \
            --timeout 300
-    else
-        echo "Skipping deploy because branch is not master"
-    fi
+    # else
+    #     echo "Skipping deploy because branch is not master"
+    # fi
 else
     echo "Skipping deploy because it's a pull request"
 fi

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -4,7 +4,7 @@
 if [ -z "$TRAVIS_PULL_REQUEST" ] || [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
 
     # Push only if we're testing the master branch
-#    if [ "$TRAVIS_BRANCH" == "master" ]; then
+   if [ "$TRAVIS_BRANCH" == "master" ]; then
 
         echo Getting the ECR login...
         eval $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
@@ -29,9 +29,9 @@ if [ -z "$TRAVIS_PULL_REQUEST" ] || [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
            --cluster "$ECS_CLUSTER"   \
            --image "$REMOTE_DOCKER_PATH":latest \
            --timeout 300
-    # else
-    #     echo "Skipping deploy because branch is not master"
-    # fi
+    else
+        echo "Skipping deploy because branch is not master"
+    fi
 else
     echo "Skipping deploy because it's a pull request"
 fi


### PR DESCRIPTION
This was a failed attempt to address the `InsecurePlatformWarning` that didn't turn out to be a build/deploy blocker.

Removing this to keep unnecessary crap out of code that others might someday want to re-use.