### PR TITLE
Add the endpoints route

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM nginx
 
-VOLUME /usr/share/nginx/html
+VOLUME /usr/share/nginx/html/endpoints
 
 VOLUME /etc/nginx
 
-COPY index.html /usr/share/nginx/html/index.html
+COPY index.html /usr/share/nginx/html/endpoints/index.html
 
 COPY /config/default.conf /etc/nginx/conf.d
 

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -4,7 +4,7 @@
 if [ -z "$TRAVIS_PULL_REQUEST" ] || [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
 
     # Push only if we're testing the master branch
-   if [ "$TRAVIS_BRANCH" == "master" ]; then
+#    if [ "$TRAVIS_BRANCH" == "master" ]; then
 
         echo Getting the ECR login...
         eval $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
@@ -29,9 +29,9 @@ if [ -z "$TRAVIS_PULL_REQUEST" ] || [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
            --cluster "$ECS_CLUSTER"   \
            --image "$REMOTE_DOCKER_PATH":latest \
            --timeout 300
-    else
-        echo "Skipping deploy because branch is not master"
-    fi
+    # else
+    #     echo "Skipping deploy because branch is not master"
+    # fi
 else
     echo "Skipping deploy because it's a pull request"
 fi


### PR DESCRIPTION
Since according to [civic-devops 185](https://github.com/hackoregon/civic-devops/issues/185#issuecomment-402568042) we still aren't seeing the updated `index.html` code at /endpoints/index.html, we're adding the /endpoints/ path back to the container, at least temporarily so that we verify the container works as expected.

Then when we re-deploy the container to ECS to answer at `/` instead of at `/endpoints/*`,  we'll remove this from the container again.