### PR TITLE
Move assets into a common place

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,9 @@ VOLUME /usr/share/nginx/html
 VOLUME /etc/nginx
 
 COPY index.html /usr/share/nginx/html/index.html
-COPY strapdown.js /usr/share/nginx/html/strapdown.js
-COPY strapdown.css /usr/share/nginx/html/strapdown.css
-COPY themes /usr/share/nginx/html/themes
+COPY strapdown.js /usr/share/nginx/html/__assets/strapdown.js
+COPY strapdown.css /usr/share/nginx/html/__assets/strapdown.css
+COPY themes /usr/share/nginx/html/__assets/themes
 
 COPY /config/default.conf /etc/nginx/conf.d
 

--- a/index.html
+++ b/index.html
@@ -28,5 +28,5 @@
 * [The 2017 Transportation API](/transport/) ([source](https://github.com/hackoregon/transportation-backend))
 
 </xmp>
-<script src="./strapdown.js"></script>
+<script src="/__assets/strapdown.js"></script>
 </html>


### PR DESCRIPTION
Not sure how I didn't see this one coming, but the load balancer only directs `/` to this container. Now all assets other than index.html are in `__assets` so the load balancer can also direct `__assets/*` to this container.