### PR TITLE
Adding references to available 2019 APIs

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,9 +21,60 @@
 	</div>
 	<div class="sideListWrapper">
     	<ul>
+                <li class="itemStyle">
+                        <div class="itemLeft">
+                            <div class="teamTitleStyle">Built by: Hack Oregon 2019</div>
+                            <h2>Housing (IN BETA)</h2>
+                        </div>
+                        <div class="github">
+                            <a href="https://github.com/hackoregon/2019-housing-backend">
+                                <h3>View code</h3>
+                            </a>
+                        </div>	
+                        <div class="swagger">
+                            <a href="/housing2019/">
+                                <h3>Get data (COMING SOON)</h3>
+                            </a>
+                        </div>
+                    </li>        
+
+                    <li class="itemStyle">
+                            <div class="itemLeft">
+                                <div class="teamTitleStyle">Built by: Hack Oregon 2019</div>
+                                <h2>Sandbox (IN BETA)</h2>
+                            </div>
+                            <div class="github">
+                                <a href="https://github.com/hackoregon/2019-sandbox-backend">
+                                    <h3>View code</h3>
+                                </a>
+                            </div>	
+                            <div class="swagger">
+                                <a href="/sandbox/schema/">
+                                    <h3>Get data</h3>
+                                </a>
+                            </div>
+                        </li>        
+
+                        <li class="itemStyle">
+                                <div class="itemLeft">
+                                    <div class="teamTitleStyle">Built by: Hack Oregon 2019</div>
+                                    <h2>Transportation Systems (IN BETA)</h2>
+                                </div>
+                                <div class="github">
+                                    <a href="https://github.com/hackoregon/2019-transportation-systems-backend">
+                                        <h3>View code</h3>
+                                    </a>
+                                </div>	
+                                <div class="swagger">
+                                    <a href="/transportation2019/v1/schema/">
+                                        <h3>Get data</h3>
+                                    </a>
+                                </div>
+                            </li>
+
             <li class="itemStyle">
                 <div class="itemLeft">
-                    <div class="teamTitleStyle">Built by: Hack Oregon 2018</div>
+                    <div class="teamTitleStyle">Built by: Hack Oregon 2018 - 2019</div>
                     <h2>Disaster Resilience</h2>
                 </div>
                 <div class="github">


### PR DESCRIPTION
Added references to the forthcoming 2019 APIs:
- Housing
- Sandbox
- Transportation Systems

Didn't mention Education because I don't see any GitHub repo for an API for that project yet.

Also updated the Disaster Resilience API as "2018 - 2019", since it appears the 2019 Disaster elected to enhance the 2018 DR API rather than generate a whole new one.

Annotated as BETA and COMING SOON where appropriate.