### PR TITLE
Flatten the deployment of assets in the running application

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,9 @@ VOLUME /usr/share/nginx/html
 VOLUME /etc/nginx
 
 COPY index.html /usr/share/nginx/html/index.html
-COPY index.css /usr/share/nginx/html/__assets/index.css
-COPY civic-logo-animated.svg /usr/share/nginx/html/__assets/civic-logo-animated.svg
-COPY themes /usr/share/nginx/html/__assets/themes
+COPY index.css /usr/share/nginx/html/index.css
+COPY civic-logo-animated.svg /usr/share/nginx/html/civic-logo-animated.svg
+COPY themes /usr/share/nginx/html/themes
 
 COPY /config/default.conf /etc/nginx/conf.d
 


### PR DESCRIPTION
This should circumvent the existing need for additional ListenerRules in CloudFormation to send __assets/ requests to this container as well